### PR TITLE
Add endpoint to create a new plant for a user

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,10 @@
 from flask import (
     Flask,
     jsonify,
-    request
+    request,
 )
 from flask_pymongo import PyMongo
-import pdb
+from bson.objectid import ObjectId
 
 app = Flask(__name__)
 
@@ -22,6 +22,18 @@ def get_one_user(user_id):
         'plants': user_plants
     }
     return jsonify({'user': response})
+
+@app.route('/api/v1/users/<int:user_id>/plants', methods=['POST'])
+def create_plant(user_id):
+    user = mongo.db.users.find_one_or_404({'_id': user_id})
+    plant = {
+        '_id': str(ObjectId()),
+        'user_id': user_id,
+        'plant_name': request.json.get('plant_name', ''),
+        'plant_type': request.json.get('plant_type', '')
+    }
+    mongo.db.plants.insert_one(plant)
+    return jsonify(plant)
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
Co-authored-by: Cassie caachzenick@gmail.com

### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling/UX
### Detailed Description
Allows a user to post a new plant to the plants database through the following uri:
/api/v1/users/<user_id>/plants
### What Issue does this fix?
Closes issue #4 
### Why is this change required? What problem does it solve?
To allow for the creation of new plants, tied to a specific user.
### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
Cassie is experiencing some environment issues, we wrote identical code but it only worked on my machine, despite seemingly identical dependencies installed through pip
### Components/Files modified:
- [x] app.py
