### PR TITLE
Add endpoint for deleting a plant

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,5 +35,12 @@ def create_plant(user_id):
     mongo.db.plants.insert_one(plant)
     return jsonify(plant)
 
+@app.route('/api/v1/users/<int:user_id>/plants/<string:plant_id>', methods=['DELETE'])
+def delete_plant(user_id, plant_id):
+    user = mongo.db.users.find_one_or_404({'_id': user_id})
+    plant = mongo.db.plants.find_one_or_404({'_id': plant_id})
+    mongo.db.plants.delete_one({'_id': plant_id})
+    return jsonify(plant)   
+
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
Co-authored-by: Cassie caachzenick@gmail.com

### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling/UX
### Detailed Description
Adds an endpoint to delete a plant by its id using the following uri:
/api/v1/users/<user_id>/plants/<plant_id>
### What Issue does this fix?
Closes issue #8 
### Why is this change required? What problem does it solve?
Users need a way to delete plants that they added.
### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
Smooth sailing.
### Components/Files modified:
- [x] app.py