### PR TITLE
Add endpoint for updating a plant

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,7 +40,15 @@ def delete_plant(user_id, plant_id):
     user = mongo.db.users.find_one_or_404({'_id': user_id})
     plant = mongo.db.plants.find_one_or_404({'_id': plant_id})
     mongo.db.plants.delete_one({'_id': plant_id})
-    return jsonify(plant)   
+    return jsonify(plant)
+
+@app.route('/api/v1/users/<int:user_id>/plants/<string:plant_id>', methods=['PATCH'])
+def update_plant(user_id, plant_id):
+    user = mongo.db.users.find_one_or_404({'_id': user_id})
+    plant = mongo.db.plants.find_one_or_404({'_id': plant_id})
+    mongo.db.plants.update_one({'_id': plant_id}, {'$set': request.json})
+    updated_plant = mongo.db.plants.find_one({'_id': plant_id})
+    return jsonify(updated_plant)
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
Co-authored-by: Cassie caachzenick@gmail.com

### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling/UX
### Detailed Description
Allows a user to update a plant by its id with no restrictions at the following uri:
/api/v1/users/<user_id>/plants/<plant_id>
### What Issue does this fix?
Closes issue #7 
### Why is this change required? What problem does it solve?
Setting up the functionality for the possibility of needing to update in the future.
### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
Not necessarily a challenge, but in the future there needs to be some kind of validation going on so the user can't add bad attributes or overwrite the id
### Components/Files modified:
- [x] app.py
