### PR TITLE
Plant and Journal CRUD Reformat

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,30 +24,48 @@ def get_one_user(user_id):
     }
     return jsonify({'user': response})
 
-@app.route('/api/v1/users/<int:user_id>/plants', methods=['GET'])
+@app.route('/api/v1/users/<string:user_id>/plants', methods=['GET'])
 def get_user_plants(user_id):
     user = mongo.db.users.find_one_or_404({'_id': user_id})
     user_plants = mongo.db.plants.find({'user_id': user_id})
     format_plant = lambda plant: {
-        'plant_id': plant['_id'],
-        'user_id': plant['user_id'],
-        'nickname': plant['nickname'],
-        'plant_type': plant['plant_type']
+        'id': plant['_id'],
+        'userId': plant['user_id'],
+        'plantName': plant['plant_name'],
+        'plantType': plant['plant_type'],
+        'imageURL': plant['image_url'],
+        'care': plant['care']
     }
     response = list(map(format_plant, list(user_plants)))
     return jsonify({'plants': response})
 
+@app.route('/api/v1/users/<string:user_id>/plants/<string:plant_id>', methods=['GET'])
+def get_one_plant(user_id, plant_id):
+    user = mongo.db.users.find_one_or_404({'_id': user_id})
+    plant = mongo.db.plants.find_one_or_404({'_id': plant_id})
+    response = {
+        'id': plant_id,
+        'userId': user_id,
+        'plantName': plant['plant_name'],
+        'plantType': plant['plant_type'],
+        'timestamp': plant['timestamp'],
+        'imageURL': plant['image_url'],
+        'care': plant['care']
+    }
+    return jsonify({'plant': response})
 
-@app.route('/api/v1/users/<int:user_id>/plants', methods=['POST'])
+@app.route('/api/v1/users/<string:user_id>/plants', methods=['POST'])
 def create_plant(user_id):
     user = mongo.db.users.find_one_or_404({'_id': user_id})
     timestamp = int(datetime.now().timestamp() * 1000)
     plant = {
         '_id': str(ObjectId()),
         'user_id': user_id,
-        'plant_name': request.json.get('plant_name', ''),
-        'plant_type': request.json.get('plant_type', ''),
-        'timestamp': timestamp
+        'plant_name': request.json.get('plantName', ''),
+        'plant_type': request.json.get('plantType', ''),
+        'timestamp': timestamp,
+        'image_url': request.json.get('imageURL', ''),
+        'care': request.json.get('care', {})
     }
     mongo.db.plants.insert_one(plant)
     return jsonify(plant)

--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from flask import (
 from flask_pymongo import PyMongo
 from bson.objectid import ObjectId
 import requests
+from datetime import datetime
 
 app = Flask(__name__)
 
@@ -13,12 +14,13 @@ app.config['MONGO_DBNAME'] = 'root_directory'
 app.config['MONGO_URI'] = 'mongodb+srv://admin:OeMp96cSKTBrjtFz@cluster0-anyov.mongodb.net/root_directory?retryWrites=true&w=majority'
 mongo = PyMongo(app)
 
-@app.route('/api/v1/users/<int:user_id>', methods=['GET'])
+@app.route('/api/v1/users/<string:user_id>', methods=['GET'])
 def get_one_user(user_id):
     user = mongo.db.users.find_one_or_404({'_id': user_id})
     response = {
-        'user_id': user['_id'],
-        'user_name': user['name']
+        'id': user['_id'],
+        'userName': user['name'],
+        'timestamp': user['timestamp']
     }
     return jsonify({'user': response})
 
@@ -39,11 +41,13 @@ def get_user_plants(user_id):
 @app.route('/api/v1/users/<int:user_id>/plants', methods=['POST'])
 def create_plant(user_id):
     user = mongo.db.users.find_one_or_404({'_id': user_id})
+    timestamp = int(datetime.now().timestamp() * 1000)
     plant = {
         '_id': str(ObjectId()),
         'user_id': user_id,
         'plant_name': request.json.get('plant_name', ''),
-        'plant_type': request.json.get('plant_type', '')
+        'plant_type': request.json.get('plant_type', ''),
+        'timestamp': timestamp
     }
     mongo.db.plants.insert_one(plant)
     return jsonify(plant)


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling/UX
### Detailed Description
Added CRUD endpoints for plants and journal entries. Formatted the output along with agreed upon contract: https://gist.github.com/jonathan-tschida/16ee0c2fb171b2428e0deaa3cbeeaf1d
### What Issue does this fix?
closes issue #6 
### Why is this change required? What problem does it solve?
Front End can now get all the endpoints they have outlined. 
### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
Unsure if photo uploading should remain its own endpoint or if that action should be included in the plant and journal create since that is where the image is coming in. 
### Components/Files modified:
app.py
