### PR TITLE
Linked delete

### DIFF
--- a/app.py
+++ b/app.py
@@ -103,6 +103,7 @@ def delete_plant(user_id, plant_id):
     user = app.mongo.db.users.find_one_or_404({'_id': user_id})
     plant = app.mongo.db.plants.find_one_or_404({'_id': plant_id})
     app.mongo.db.plants.delete_one({'_id': plant_id})
+    app.mongo.db.journal.delete_many({'plant_id': plant_id})
     return jsonify(plant)
 
 # Journals

--- a/test.py
+++ b/test.py
@@ -112,15 +112,32 @@ class TestFlaskCase(unittest.TestCase):
             'image_url': 'www.aws.com/s3/image.jpg',
             'care': {}
         }
+        journal_doc = {
+            '_id': '5e12g8f',
+            'plant_id': '5e12g5c',
+            'timestamp': 1590863754003,
+            'entry_type': 'image',
+            'info': {
+                'imageURL': 'www.aws.com/s3/image.jpg',
+                'notes': ''
+            }
+
+        }
         self.mongo.db.plants.insert_one(plant_doc)
+        self.mongo.db.journal.insert_one(journal_doc)
         plant = self.mongo.db.plants.find_one({'_id': '5e12g5c'})
+        journals_before = list(self.mongo.db.journal.find({'plant_id': '5e12g5c'}))
         self.assertEqual(plant['plant_name'], 'Bob')
+        self.assertEqual(len(journals_before), 1)
 
         response = self.app.delete('/api/v1/users/5e12g4a/plants/5e12g5c')
         db = list(self.mongo.db.plants.find())
+        journals_after = list(self.mongo.db.journal.find({'plant_id': '5e12g5c'}))
+
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json['plant_name'], 'Bob')
         self.assertEqual(len(db), 0)
+        self.assertEqual(len(journals_after), 0)
 
     def test_get_plant_journal(self):
         plant_doc = {


### PR DESCRIPTION
### Type of change made:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling/UX
### Detailed Description
Previously when a plant was deleted from the database, its journal entries would persist, causing the database to contain a lot of plantless entries.  Now when a plant is deleted, all journal entries with that plant_id will also be deleted.
### What Issue does this fix?
### Why is this change required? What problem does it solve?
Keeps the database from being cluttered with orphaned journal entries.
### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
### Components/Files modified:
 - [x] app.py
 - [x] test.py
